### PR TITLE
Disable NextImage for some images

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -1,7 +1,18 @@
 import Image from './Image'
 import Link from './Link'
 
-const Card = ({ title, description, imgSrc, href, width = 1088, height = 612 }) => (
+const OptimizedImage = ({ imageOptimize, ...rest }) =>
+  imageOptimize ? <Image {...rest} /> : <img {...rest} />
+
+const Card = ({
+  title,
+  description,
+  imgSrc,
+  href,
+  width = 1088,
+  height = 612,
+  imageOptimize = true,
+}) => (
   <div className="p-4">
     <div className="h-full overflow-hidden border-2 border-gray-200 rounded-md border-opacity-60 dark:border-gray-700">
       <div className="p-6">
@@ -18,21 +29,23 @@ const Card = ({ title, description, imgSrc, href, width = 1088, height = 612 }) 
       </div>
       {href ? (
         <Link href={href} aria-label={`Link to ${title}`}>
-          <Image
+          <OptimizedImage
             alt={title}
             src={imgSrc}
             className="object-cover object-center"
             width={width}
             height={height}
+            imageOptimize={imageOptimize}
           />
         </Link>
       ) : (
-        <Image
+        <OptimizedImage
           alt={title}
           src={imgSrc}
           className="object-cover object-center"
           width={width}
           height={height}
+          imageOptimize={imageOptimize}
         />
       )}
     </div>

--- a/data/weatherData.js
+++ b/data/weatherData.js
@@ -12,6 +12,7 @@ const projectsData = [
     href: 'https://cdn.star.nesdis.noaa.gov/GOES16/ABI/SECTOR/taw/GEOCOLOR/1800x1080.jpg',
     width: '1800',
     height: '1080',
+    imageOptimize: false,
   },
   {
     title: 'Caribe',
@@ -20,6 +21,7 @@ const projectsData = [
     href: 'https://cdn.star.nesdis.noaa.gov//GOES16/ABI/SECTOR/CAR/13/GOES16-CAR-13-1000x1000.gif',
     width: '1000',
     height: '1000',
+    imageOptimize: false,
   },
   {
     title: 'Radar Doppler',
@@ -71,6 +73,7 @@ const projectsData = [
       'https://cdn.star.nesdis.noaa.gov//GOES16/ABI/SECTOR/TAW/GEOCOLOR/GOES16-TAW-GEOCOLOR-900x540.gif',
     width: '900',
     height: '540',
+    imageOptimize: false,
   },
   {
     title: 'Red Sísmica de Puerto Rico',

--- a/package-lock.json
+++ b/package-lock.json
@@ -12899,36 +12899,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.2.tgz",
-      "integrity": "sha512-VHjuCHeq9qCprUZbsRxxM/VqSW8MmsUtqB5nEpGEgUNnQi/BTm/2aK8tl7R4D0twGKRh6g1AAeFuWtXzk9Z/vQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-freebsd-x64": {
-      "version": "12.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.2.tgz",
-      "integrity": "sha512-JUnXB+2xfxqsAvhFLPJpU1NeyDsvJrKoOjpV7g3Dxbno2Riu4tDKn3kKF886yleAuD/1qNTUCpqubTvbbT2VoA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     }
   },
   "dependencies": {
@@ -22128,18 +22098,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.2.tgz",
       "integrity": "sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA=="
-    },
-    "@next/swc-android-arm-eabi": {
-      "version": "12.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.2.tgz",
-      "integrity": "sha512-VHjuCHeq9qCprUZbsRxxM/VqSW8MmsUtqB5nEpGEgUNnQi/BTm/2aK8tl7R4D0twGKRh6g1AAeFuWtXzk9Z/vQ==",
-      "optional": true
-    },
-    "@next/swc-freebsd-x64": {
-      "version": "12.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.2.tgz",
-      "integrity": "sha512-JUnXB+2xfxqsAvhFLPJpU1NeyDsvJrKoOjpV7g3Dxbno2Riu4tDKn3kKF886yleAuD/1qNTUCpqubTvbbT2VoA==",
-      "optional": true
     }
   }
 }

--- a/pages/weather.js
+++ b/pages/weather.js
@@ -26,6 +26,7 @@ export default function Projects() {
                   href={d.href}
                   width={adjustedSize.width}
                   height={adjustedSize.height}
+                  imageOptimize={d.imageOptimize}
                 />
               )
             })}


### PR DESCRIPTION
Implements a workaround for large images not being cached due to BUG at tailwind-nextjs-starter-blog. See issue https://github.com/timlrx/tailwind-nextjs-starter-blog/issues/532