### PR TITLE
Add phone number to member mobile card

### DIFF
--- a/app/admin/members/page.js
+++ b/app/admin/members/page.js
@@ -635,6 +635,13 @@ function MembersContent() {
                           )}
                         </div>
                       )}
+                      {member.phone && (
+                        <p className="text-sm text-gray-500 dark:text-gray-400 truncate mt-1">
+                          <a href={`tel:${member.phone}`} className="hover:underline">
+                            {member.phone}
+                          </a>
+                        </p>
+                      )}
                     </div>
                     <div className="flex items-center gap-2">
                       <StatusBadge status={member.status} />


### PR DESCRIPTION
## Summary
- Displays `member.phone` on the Admin Dashboard > Members tab mobile card, rendered as a `tel:` link so admins can tap to call.
- Placed under the email rows, hidden when no phone is on file.

## Test plan
- [ ] Open Admin Dashboard > Members on a mobile viewport
- [ ] Verify the phone number appears under the email(s) for members who have one
- [ ] Verify members without a phone show no extra row
- [ ] Tap the phone number and verify the native dialer opens

https://claude.ai/code/session_01Hyc6VyPQC6DDPQ18pkqEwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hyc6VyPQC6DDPQ18pkqEwM)_